### PR TITLE
Fixed NavBar for mobile

### DIFF
--- a/src/components/App/styled.ts
+++ b/src/components/App/styled.ts
@@ -11,6 +11,10 @@ export const GlobalStyles = createGlobalStyle`
 		-moz-osx-font-smoothing: grayscale;
 		color: ${({ theme }) => theme.text.primary};
 		background-color: ${({ theme }) => theme.bg.primary};
+		
+		@media (max-width: 51em) {
+			padding-bottom: 5em;
+		}
 	}
 
 	h1 {

--- a/src/components/Button/styled.ts
+++ b/src/components/Button/styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { withAlphaHex } from 'with-alpha-hex'
 
 export const WrapperIcon = styled.div`
 	width: 3.2em;
@@ -29,17 +28,15 @@ export const StyledButton = styled.button`
 
 	font-family: Verdana, Geneva, Tahoma, sans-serif;
 	color: ${({ theme }) => theme.text.secondary};
-	background-color: ${({ theme }) =>
-		withAlphaHex(theme.bg.buttonBackground, 0.5)};
+	background-color: ${({ theme }) => theme.bg.buttonBackground};
 	cursor: pointer;
 
-	border: 0.1em solid ${({ theme }) => withAlphaHex(theme.bg.secondary, 0.5)};
+	border: 0.1em solid ${({ theme }) => theme.bg.secondary};
 	border-radius: 0.8em;
 	outline: none;
 
 	&:hover {
 		color: ${({ theme }) => theme.bg.primary};
-		background-color: ${({ theme }) =>
-			withAlphaHex(theme.text.secondary, 0.7)};
+		background-color: ${({ theme }) => theme.text.secondary};
 	}
 `

--- a/src/components/ButtonNav/styled.ts
+++ b/src/components/ButtonNav/styled.ts
@@ -10,7 +10,7 @@ export const Wrapper = styled.nav`
 	align-content: center;
 
 	@media (max-width: 51em) {
-		position: absolute;
+		position: fixed;
 		bottom: 0;
 	}
 `
@@ -26,6 +26,7 @@ export const StyledLink = styled(Link)`
 
 	@media (max-width: 51em) {
 		flex: 1;
+		height: 6em;
 		& > button {
 			border-radius: 0;
 		}


### PR DESCRIPTION
Transparency removed and navigation fixed at the bottom. The biggest problem was the hidden text behind the menu. I tried to solve the problem by creating a second wrapper, which got NavBar off the bar, but did not solve the hidden text! Then I copied the NavBar, but it was a lot of duplicate code. in the end I solved it by adjusting the height and moving the lower edge.

If you know of a better solution, suggestions are welcome.