### PR TITLE
Add logo instead of styled-icon

### DIFF
--- a/src/assets/Logo/index.tsx
+++ b/src/assets/Logo/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+
+export const Logo: React.FC = () => (
+	<svg height="10em" width="10em" viewBox="0 0 300 300">
+		<circle
+			cx="150"
+			cy="150"
+			r="145"
+			stroke="currentColor"
+			strokeWidth="0.2em"
+			fill="none"
+			alignmentBaseline="middle"
+		/>
+		<text
+			x="145"
+			y="135"
+			textAnchor="middle"
+			fontSize="3em"
+			fill="currentColor"
+		>
+			{' '}
+			[: aj tý: ]
+		</text>
+		<text
+			x="145"
+			y="200"
+			textAnchor="middle"
+			fontSize="3em"
+			fill="currentColor"
+		>
+			{' '}
+			spojka
+		</text>
+	</svg>
+)
+
+export default Logo

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -2,7 +2,8 @@ import React from 'react'
 import { Theme, useThemeControl } from '../Theme'
 import Toggle from '../Toggle'
 import { ButtonNav } from '../ButtonNav'
-import { Wrapper, StyledLink, Logo } from './styled'
+import { Wrapper, StyledLink } from './styled'
+import Logo from '../../assets/Logo/'
 
 interface Props {
 	login: boolean

--- a/src/components/NavBar/styled.ts
+++ b/src/components/NavBar/styled.ts
@@ -1,5 +1,4 @@
 import styled from 'styled-components'
-import { ConnectWithoutContact } from '@styled-icons/material-rounded'
 import { Link } from 'react-router-dom'
 
 export const Wrapper = styled.header`
@@ -16,14 +15,10 @@ export const Wrapper = styled.header`
 	}
 `
 
-export const Logo = styled(ConnectWithoutContact)`
-	width: 10em;
-	padding: 1em;
-`
-
 export const StyledLink = styled(Link)`
 	color: ${({ theme }) => theme.text.primary};
 	grid-column: 2;
+	padding: 2em;
 
 	@media (max-width: 80em) {
 		grid-column: 1;


### PR DESCRIPTION
Just a little experiment so we can use title of our project as a logo instead of an icon or header (as was said during the last call). Provided y'all like it. 

![menu1](https://user-images.githubusercontent.com/76131194/107567404-eba3de80-6be5-11eb-9f69-52c209fb279b.png)

![menu2](https://user-images.githubusercontent.com/76131194/107567399-e9da1b00-6be5-11eb-809e-928701e547c9.png)
