### PR TITLE
Contacts

### DIFF
--- a/src/components/App/index.tsx
+++ b/src/components/App/index.tsx
@@ -7,12 +7,14 @@ import { GlobalStyles } from './styled'
 // Pages
 import Home from '../../pages/Home'
 import Login from '../../pages/Login'
+import Contacts from '../../pages/Contacts'
 import Register from '../../pages/Register'
 
 const Routes: React.FC = () => (
 	<Switch>
 		<Route path="/login" component={Login} />
 		<Route path="/register" component={Register} />
+		<Route path="/contacts" component={Contacts} />
 		<Route path="/" component={Home} />
 	</Switch>
 )

--- a/src/components/Message/components/AwaitingResponseMessage/index.tsx
+++ b/src/components/Message/components/AwaitingResponseMessage/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 	message: string
 }
 
-const MatchMessage: React.FC<Props> = ({ message }) => (
+const AwaitingResponseMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
 			<MessageAvatar />
@@ -26,4 +26,4 @@ const MatchMessage: React.FC<Props> = ({ message }) => (
 	</>
 )
 
-export default MatchMessage
+export default AwaitingResponseMessage

--- a/src/components/Message/components/AwaitingResponseMessage/index.tsx
+++ b/src/components/Message/components/AwaitingResponseMessage/index.tsx
@@ -5,6 +5,7 @@ import {
 	MessageAvatar,
 	MessageBody,
 	MessageButton,
+	ButtonBox,
 } from '../../styled'
 import ReadMore from '../ReadMore'
 
@@ -15,12 +16,18 @@ type Props = {
 const AwaitingResponseMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
+			{/* TODO: Add this avatar of last-message author */}
 			<MessageAvatar />
 			<MessageBody>
 				{message}
 				<ReadMore message={message} />
 			</MessageBody>
-			<MessageButton />
+			{/* TODO: Add button submit functionality */}
+			<ButtonBox>
+				<MessageButton name="submit" type="submit">
+					SMAZAT
+				</MessageButton>
+			</ButtonBox>
 		</MessageBox>
 		<BreakLine />
 	</>

--- a/src/components/Message/components/IgnoredMessage/index.tsx
+++ b/src/components/Message/components/IgnoredMessage/index.tsx
@@ -5,6 +5,7 @@ import {
 	MessageAvatar,
 	MessageBody,
 	MessageButton,
+	ButtonBox,
 } from '../../styled'
 import ReadMore from '../ReadMore'
 
@@ -15,12 +16,21 @@ type Props = {
 const IgnoredMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
+			{/* TODO: Add this avatar of last-message author */}
 			<MessageAvatar />
 			<MessageBody>
 				{message}
 				<ReadMore message={message} />
 			</MessageBody>
-			<MessageButton />
+			{/* TODO: Add button submit functionality */}
+			<ButtonBox>
+				<MessageButton name="submit" type="submit">
+					OBNOVIT
+				</MessageButton>
+				<MessageButton name="submit" type="submit">
+					SMAZAT
+				</MessageButton>
+			</ButtonBox>
 		</MessageBox>
 		<BreakLine />
 	</>

--- a/src/components/Message/components/IgnoredMessage/index.tsx
+++ b/src/components/Message/components/IgnoredMessage/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 	message: string
 }
 
-const MatchMessage: React.FC<Props> = ({ message }) => (
+const IgnoredMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
 			<MessageAvatar />
@@ -26,4 +26,4 @@ const MatchMessage: React.FC<Props> = ({ message }) => (
 	</>
 )
 
-export default MatchMessage
+export default IgnoredMessage

--- a/src/components/Message/components/MatchMessage/index.tsx
+++ b/src/components/Message/components/MatchMessage/index.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import {
+	MessageAvatar,
+	MessageBody,
+	MessageBox,
+	MessageButton,
+	ReadMore,
+} from '../../styled'
+
+type Props = {
+	message: string
+}
+
+const MatchMessage: React.FC<Props> = ({ message }) => (
+	<MessageBox>
+		<MessageAvatar />
+		<MessageBody>
+			{message}
+			<ReadMore hidden={message.length <= 250}>[zbytek zprávy]</ReadMore>
+		</MessageBody>
+		<MessageButton />
+	</MessageBox>
+)
+
+export default MatchMessage

--- a/src/components/Message/components/MatchMessage/index.tsx
+++ b/src/components/Message/components/MatchMessage/index.tsx
@@ -5,6 +5,7 @@ import {
 	MessageAvatar,
 	MessageBody,
 	MessageButton,
+	ButtonBox,
 } from '../../styled'
 import ReadMore from '../ReadMore'
 
@@ -15,12 +16,18 @@ type Props = {
 const MatchMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
+			{/* TODO: Add this avatar of last-message author */}
 			<MessageAvatar />
 			<MessageBody>
 				{message}
 				<ReadMore message={message} />
 			</MessageBody>
-			<MessageButton />
+			{/* TODO: Add button submit functionality */}
+			<ButtonBox>
+				<MessageButton name="submit" type="submit">
+					ODPOVĚDĚT
+				</MessageButton>
+			</ButtonBox>
 		</MessageBox>
 		<BreakLine />
 	</>

--- a/src/components/Message/components/NewMatchMessage/index.tsx
+++ b/src/components/Message/components/NewMatchMessage/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react'
 import {
 	BreakLine,
+	ButtonBox,
 	MessageBox,
 	MessageAvatar,
 	MessageBody,
@@ -15,12 +16,21 @@ type Props = {
 const NewMatchMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
+			{/* TODO: Add this avatar of last-message author */}
 			<MessageAvatar />
 			<MessageBody>
 				{message}
 				<ReadMore message={message} />
 			</MessageBody>
-			<MessageButton />
+			{/* TODO: Add button submit functionality */}
+			<ButtonBox>
+				<MessageButton name="submit" type="submit">
+					PŘIJMOUT
+				</MessageButton>
+				<MessageButton name="submit" type="submit">
+					ODMÍTNOUT
+				</MessageButton>
+			</ButtonBox>
 		</MessageBox>
 		<BreakLine />
 	</>

--- a/src/components/Message/components/NewMatchMessage/index.tsx
+++ b/src/components/Message/components/NewMatchMessage/index.tsx
@@ -12,7 +12,7 @@ type Props = {
 	message: string
 }
 
-const MatchMessage: React.FC<Props> = ({ message }) => (
+const NewMatchMessage: React.FC<Props> = ({ message }) => (
 	<>
 		<MessageBox>
 			<MessageAvatar />
@@ -26,4 +26,4 @@ const MatchMessage: React.FC<Props> = ({ message }) => (
 	</>
 )
 
-export default MatchMessage
+export default NewMatchMessage

--- a/src/components/Message/components/ReadMore/index.tsx
+++ b/src/components/Message/components/ReadMore/index.tsx
@@ -1,0 +1,14 @@
+import React from 'react'
+import { ReadMoreStyled } from './styled'
+
+type Props = {
+	message: string
+}
+
+const ReadMore: React.FC<Props> = ({ message }) => (
+	<ReadMoreStyled hidden={message.length <= 250}>
+		[zbytek zprávy]
+	</ReadMoreStyled>
+)
+
+export default ReadMore

--- a/src/components/Message/components/ReadMore/index.tsx
+++ b/src/components/Message/components/ReadMore/index.tsx
@@ -5,6 +5,7 @@ type Props = {
 	message: string
 }
 
+// TODO: Add functionality of "ReadMore" component
 const ReadMore: React.FC<Props> = ({ message }) => (
 	<ReadMoreStyled hidden={message.length <= 250}>
 		[zbytek zprávy]

--- a/src/components/Message/components/ReadMore/styled.ts
+++ b/src/components/Message/components/ReadMore/styled.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const ReadMoreStyled = styled.span`
+	color: ${({ theme }) => theme.text.secondary};
+	margin-left: 0.5em;
+	text-decoration: underline;
+	cursor: pointer;
+`

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -1,0 +1,37 @@
+import React from 'react'
+import MatchMessage from './components/MatchMessage'
+import { Wrapper } from './styled'
+
+export enum MessageType {
+	MATCH = 'MATCH',
+	IGNORED = 'IGNORED',
+	NEW_MATCH = 'NEW_MATCH',
+	AWAITING_RESPONSE = 'AWAITING_RESPONSE',
+}
+
+export type MessageData = {
+	type: MessageType
+	content: string
+}
+
+type Props = {
+	message: MessageData
+}
+
+const chooseMessageByType = (message: MessageData) => {
+	switch (message.type) {
+		case MessageType.MATCH:
+			return <MatchMessage message={message.content} />
+		case MessageType.IGNORED:
+		case MessageType.NEW_MATCH:
+		case MessageType.AWAITING_RESPONSE:
+		default:
+		// Invalid message type
+	}
+}
+
+const Message: React.FC<Props> = ({ message }) => (
+	<Wrapper>{chooseMessageByType(message)}</Wrapper>
+)
+
+export default Message

--- a/src/components/Message/index.tsx
+++ b/src/components/Message/index.tsx
@@ -1,12 +1,16 @@
 import React from 'react'
+
+// Message Components
+import AwaitingResponseMessage from './components/AwaitingResponseMessage'
+import IgnoredMessage from './components/IgnoredMessage'
 import MatchMessage from './components/MatchMessage'
-import { Wrapper } from './styled'
+import NewMatchMessage from './components/NewMatchMessage'
 
 export enum MessageType {
-	MATCH = 'MATCH',
-	IGNORED = 'IGNORED',
 	NEW_MATCH = 'NEW_MATCH',
+	MATCH = 'MATCH',
 	AWAITING_RESPONSE = 'AWAITING_RESPONSE',
+	IGNORED = 'IGNORED',
 }
 
 export type MessageData = {
@@ -20,18 +24,21 @@ type Props = {
 
 const chooseMessageByType = (message: MessageData) => {
 	switch (message.type) {
+		case MessageType.NEW_MATCH:
+			return <NewMatchMessage message={message.content} />
 		case MessageType.MATCH:
 			return <MatchMessage message={message.content} />
-		case MessageType.IGNORED:
-		case MessageType.NEW_MATCH:
 		case MessageType.AWAITING_RESPONSE:
+			return <AwaitingResponseMessage message={message.content} />
+		case MessageType.IGNORED:
+			return <IgnoredMessage message={message.content} />
 		default:
 		// Invalid message type
 	}
 }
 
 const Message: React.FC<Props> = ({ message }) => (
-	<Wrapper>{chooseMessageByType(message)}</Wrapper>
+	<>{chooseMessageByType(message)}</>
 )
 
 export default Message

--- a/src/components/Message/styled.ts
+++ b/src/components/Message/styled.ts
@@ -1,4 +1,5 @@
 import styled from 'styled-components'
+import { StyledButton } from '../Button/styled'
 
 export const Wrapper = styled.section`
 	display: grid;
@@ -85,24 +86,13 @@ export const MessageBody = styled.p`
 	}
 `
 
-export const MessageButton = styled.button`
-	background-color: ${({ theme }) => theme.bg.secondary};
-	background-color: #2a9d8f;
-	width: 6vw;
-	height: 6vw;
-	border-radius: 50%;
-	border: none;
-
-	@media (max-width: 50em) {
-		width: 12vw;
-		height: 12vw;
-	}
-
-	@media (max-width: 30em) {
-		width: 18vw;
-		height: 18vw;
-	}
+export const ButtonBox = styled.div`
+	display: flex;
+	flex-flow: column nowrap;
+	row-gap: 1em;
 `
+
+export const MessageButton = styled(StyledButton)``
 
 export const BreakLine = styled.hr`
 	margin: 1.5em;

--- a/src/components/Message/styled.ts
+++ b/src/components/Message/styled.ts
@@ -1,0 +1,100 @@
+import styled from 'styled-components'
+
+export const Wrapper = styled.section`
+	display: grid;
+	grid-template-columns: 1fr 5fr 1fr;
+	justify-items: center;
+	justify-content: center;
+`
+
+export const MessageBoxTitle = styled.h1`
+	grid-column: 2;
+	font-size: 2em;
+	text-align: center;
+	margin: 0;
+`
+
+export const MessageBox = styled.div`
+	grid-column: 2;
+	width: 80%;
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-around;
+	align-items: center;
+	padding: 2em;
+	margin: 2em;
+	border: 0.1em solid ${({ theme }) => theme.bg.secondary};
+	border-radius: 0.8em;
+
+	@media (max-width: 80em) {
+		width: 75%;
+	}
+
+	@media (max-width: 50em) {
+		grid-template-columns: 1fr;
+		flex-wrap: wrap;
+		width: 50%;
+		padding-left: 0.5em;
+		padding-right: 0.5em;
+		padding-top: 1.5em;
+		padding-bottom: 1.5em;
+	}
+`
+
+export const MessageAvatar = styled.div`
+	border: 0.4em solid ${({ theme }) => theme.bg.secondary};
+	border-radius: 50%;
+	width: 5vw;
+	height: 5vw;
+
+	@media (max-width: 50em) {
+		width: 11vw;
+		height: 11vw;
+	}
+
+	@media (max-width: 30em) {
+		width: 17vw;
+		height: 17vw;
+	}
+`
+
+export const MessageBody = styled.p`
+	margin: 2em;
+	width: 70ch;
+
+	@media (max-width: 80em) {
+		margin: 1.5em;
+		width: 60ch;
+	}
+
+	@media (max-width: 50em) {
+		margin: 1em;
+		width: 45ch;
+	}
+`
+
+export const ReadMore = styled.span`
+	color: ${({ theme }) => theme.text.secondary};
+	margin-left: 0.5em;
+	text-decoration: underline;
+	cursor: pointer;
+`
+
+export const MessageButton = styled.button`
+	background-color: ${({ theme }) => theme.bg.secondary};
+	background-color: #2a9d8f;
+	width: 6vw;
+	height: 6vw;
+	border-radius: 50%;
+	border: none;
+
+	@media (max-width: 50em) {
+		width: 12vw;
+		height: 12vw;
+	}
+
+	@media (max-width: 30em) {
+		width: 18vw;
+		height: 18vw;
+	}
+`

--- a/src/components/Message/styled.ts
+++ b/src/components/Message/styled.ts
@@ -9,18 +9,20 @@ export const Wrapper = styled.section`
 
 export const MessageBoxTitle = styled.h1`
 	grid-column: 2;
-	font-size: 2em;
+	font-size: 1.8rem;
 	text-align: center;
 	margin: 0;
+	text-transform: uppercase;
+	color: ${({ theme }) => theme.text.secondary};
+
+	@media (max-width: 50em) {
+		margin-bottom: 0.7em;
+	}
 `
 
-export const MessageBox = styled.div`
+export const MessageBoxBorder = styled.div`
 	grid-column: 2;
 	width: 80%;
-	display: flex;
-	flex-flow: row nowrap;
-	justify-content: space-around;
-	align-items: center;
 	padding: 2em;
 	margin: 2em;
 	border: 0.1em solid ${({ theme }) => theme.bg.secondary};
@@ -32,12 +34,22 @@ export const MessageBox = styled.div`
 
 	@media (max-width: 50em) {
 		grid-template-columns: 1fr;
-		flex-wrap: wrap;
 		width: 50%;
 		padding-left: 0.5em;
 		padding-right: 0.5em;
 		padding-top: 1.5em;
 		padding-bottom: 1.5em;
+	}
+`
+
+export const MessageBox = styled.div`
+	display: flex;
+	flex-flow: row nowrap;
+	justify-content: space-around;
+	align-items: center;
+
+	@media (max-width: 50em) {
+		flex-wrap: wrap;
 	}
 `
 
@@ -73,13 +85,6 @@ export const MessageBody = styled.p`
 	}
 `
 
-export const ReadMore = styled.span`
-	color: ${({ theme }) => theme.text.secondary};
-	margin-left: 0.5em;
-	text-decoration: underline;
-	cursor: pointer;
-`
-
 export const MessageButton = styled.button`
 	background-color: ${({ theme }) => theme.bg.secondary};
 	background-color: #2a9d8f;
@@ -96,5 +101,25 @@ export const MessageButton = styled.button`
 	@media (max-width: 30em) {
 		width: 18vw;
 		height: 18vw;
+	}
+`
+
+export const BreakLine = styled.hr`
+	margin: 1.5em;
+	height: 0.15em;
+	background-color: #e9c46a;
+	border-width: 0;
+	border-radius: 50%;
+
+	:last-child {
+		display: none;
+	}
+
+	@media (max-width: 50em) {
+		margin: 1em;
+	}
+
+	@media (max-width: 30em) {
+		margin: 1.5em;
 	}
 `

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+
+// Components
+import Message, { MessageData, MessageType } from '../components/Message'
+import { MessageBoxTitle } from '../components/Message/styled'
+import NavBar from '../components/NavBar'
+
+const fakeMessages: MessageData[] = [
+	{
+		content:
+			'M1: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.MATCH,
+	},
+	{
+		content:
+			'M2: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:M2: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.MATCH,
+	},
+	{
+		content:
+			'Like any other social media site Facebook has length requirements when it comes to writing on the wall, providing status, messaging and commenting. Understanding how many characters you can use, enables you to more effectively use Facebook as a busi.',
+		type: MessageType.MATCH,
+	},
+]
+
+const Contacts: React.FC = () => {
+	return (
+		<>
+			<NavBar login={true} />
+			<MessageBoxTitle>Titulek</MessageBoxTitle>
+			{fakeMessages.map((message, index) => (
+				<>
+					<Message key={index} message={message} />
+				</>
+			))}
+		</>
+	)
+}
+
+export default Contacts

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -9,6 +9,7 @@ import {
 } from '../components/Message/styled'
 import NavBar from '../components/NavBar'
 
+// TODO: Discard fakeMessages when our own API is ready
 const fakeMessages: MessageData[] = [
 	{
 		content:
@@ -92,7 +93,8 @@ const Contacts: React.FC = () => {
 		<>
 			<NavBar login={true} />
 			<Wrapper>
-				{/* TODO: In case of no messages, display some message */}
+				{/* TODO: Add message in case of no messages in any cathegory */}
+				{/* TODO: Handle new/unread messages style and notifications */}
 				{Object.entries(messagesGroups).map(([type, messages]) => (
 					<MessageBoxBorder key={type} hidden={messages.length === 0}>
 						<MessageBoxTitle>

--- a/src/pages/Contacts.tsx
+++ b/src/pages/Contacts.tsx
@@ -2,10 +2,19 @@ import React from 'react'
 
 // Components
 import Message, { MessageData, MessageType } from '../components/Message'
-import { MessageBoxTitle } from '../components/Message/styled'
+import {
+	MessageBoxBorder,
+	MessageBoxTitle,
+	Wrapper,
+} from '../components/Message/styled'
 import NavBar from '../components/NavBar'
 
 const fakeMessages: MessageData[] = [
+	{
+		content:
+			'M1: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.NEW_MATCH,
+	},
 	{
 		content:
 			'M1: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
@@ -18,21 +27,86 @@ const fakeMessages: MessageData[] = [
 	},
 	{
 		content:
-			'Like any other social media site Facebook has length requirements when it comes to writing on the wall, providing status, messaging and commenting. Understanding how many characters you can use, enables you to more effectively use Facebook as a busi.',
+			'M3: Like any other social media site Facebook has length requirements when it comes to writing on the wall, providing status, messaging and commenting. Understanding how many characters you can use, enables you to more effectively use Facebook as a busi.',
 		type: MessageType.MATCH,
+	},
+	{
+		content:
+			'M4: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.MATCH,
+	},
+	{
+		content:
+			'M2: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:M2: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.IGNORED,
+	},
+	{
+		content:
+			'M3: Like any other social media site Facebook has length requirements when it comes to writing on the wall, providing status, messaging and commenting. Understanding how many characters you can use, enables you to more effectively use Facebook as a busi.',
+		type: MessageType.IGNORED,
+	},
+	{
+		content:
+			'M1: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.AWAITING_RESPONSE,
+	},
+	{
+		content:
+			'M1: To create a circle, use the border-radius property and se valu o 50%.Then combine the height and width properties with a matching value:',
+		type: MessageType.AWAITING_RESPONSE,
 	},
 ]
 
+const groupMessagesByType = (
+	messages: MessageData[]
+): Record<MessageType, MessageData[]> =>
+	messages.reduce(
+		(previousGroupMessages, currentMessage) => {
+			return {
+				...previousGroupMessages,
+				[currentMessage.type]: [
+					...previousGroupMessages[currentMessage.type],
+					currentMessage,
+				],
+			}
+		},
+		{
+			[MessageType.NEW_MATCH]: [],
+			[MessageType.MATCH]: [],
+			[MessageType.AWAITING_RESPONSE]: [],
+			[MessageType.IGNORED]: [],
+		}
+	)
+
+const messageTypeTitles = {
+	[MessageType.NEW_MATCH]: 'Nové žádosti o spojení',
+	[MessageType.MATCH]: 'Přátelé',
+	[MessageType.AWAITING_RESPONSE]: 'Odeslané žádosti o spojení',
+	[MessageType.IGNORED]: 'Odmítnuté žádosti o spojení',
+}
+
 const Contacts: React.FC = () => {
+	const messagesGroups = groupMessagesByType(fakeMessages)
+
 	return (
 		<>
 			<NavBar login={true} />
-			<MessageBoxTitle>Titulek</MessageBoxTitle>
-			{fakeMessages.map((message, index) => (
-				<>
-					<Message key={index} message={message} />
-				</>
-			))}
+			<Wrapper>
+				{/* TODO: In case of no messages, display some message */}
+				{Object.entries(messagesGroups).map(([type, messages]) => (
+					<MessageBoxBorder key={type} hidden={messages.length === 0}>
+						<MessageBoxTitle>
+							{messageTypeTitles[type as MessageType]}
+						</MessageBoxTitle>
+						{messages.map((message, index) => (
+							<Message
+								key={`${type}_${index}`}
+								message={message}
+							/>
+						))}
+					</MessageBoxBorder>
+				))}
+			</Wrapper>
 		</>
 	)
 }


### PR DESCRIPTION
**Here's my PR for Contacts, it consists from following tasks:**
- Add Contacts Page and Message Component
- Add functionality to contacts page and components
- Add mock API
- Add message cathegories and corresponding components
- Add displaying messages
- Fix CSS styles according to structure changes
- Add ReadMore component
- Add buttons
- Add TODO comments

_**And now to explain the magic!**_

### PAGE

**_FUNCTION_**
We have four types of messages - with matched contacts, new match suggestions, matches I suggested and matches I ignored. To display messages in those four blocks, each block with it's title, Jindra helped me created `groupMessagesByType` function with `message: MesageData[] ` as it's parameter. MessageData[] is an array filled with information about each message (for now it's `type` and `content`).

**_TYPE_**
We set the type of `Record<MessageType, MessageData[]>`. MessageType are our four message types mentioned above defined in another file. `Record<Key, Type>` [[docs](https://www.typescriptlang.org/docs/handbook/utility-types.html#recordkeystype)] is a TypeScript device for type transformation. In this case, the object we're creating with `groupMessagesByType` function now has values of `MessageType` **as keys** and `MessageData[] `array values **as values of those keys**.

**_REDUCE_**
Now to the body of the `groupMessagesByType` function! The functional way to go through all messages a user has is `reduce`. This is mainly because reduce is immutable (you're never changing original array in the middle of your loop), it iterates over all elements in an array and accumulates them into one "thing" (whatever you define) with a return. This gives it many advantages over forEach and other loops (ways to "filter" or go through all data).

Reduce has two parameters - `array.reduce(callback[, initialValue])` (initialValue is optional). 

_FIRST PARAMETER - CALLBACK_
In our case, our `callback` is an **anonymous arrow function** `(previousGroupMessages, currentMessage) => { return ... }`. It's two parameters `previousGroupMessages` and `currentMessage` define what messages we already went through and what message we're iterating over right now.

Our anonymous array function (callback) uses so called **spread operator** `...`, which clones (copies) object it's used on. `...previousGroupMessages` therefore are all messages reduce (loop) already went through with all their types and data. As such, the loop acknowledges what `previousGroupMessages` it has, what `currentMessage` it has and then pushes the `currentMessage` into it's correct type category. The `currentMessage` becomes a part of `previousGroupMessages` and reduce goes to next iteration (evaluates next currentMessage) until there are no messages left. 

_SECOND PARAMETER - INITIAL VALUE_
Second parameter of reduce after callback (our anonymous arrow function)  is an `initialValue`. Our initialValue is `an object {} `defining `empty arrays [] `for each MessageType as in here `[MessageType.MATCH]: []`.

And when there are no messages to iterate over/go through, our reduce returns same structure as initalValue object {} with four MessageType types and each has an array full of corresponding messages. :) 
 
![reduce](https://user-images.githubusercontent.com/76131194/107968334-86b60300-6fae-11eb-96f3-2501967141c4.png)

Since we don't have a back-end/API yet, we set up an object full of `fakeMessages`.  Each one only has a `content` (it's text) and it's `type` (correspoding with `MessageType` enum defined in different file). 

_DISPLAY FAKEMESSAGES_
To display those `fakeMessages` (later our API data) in a Contact page, we create a variable `const messageGroups = groupMessagesByType(fakeMessages)` using our `groupMessagesByType` function that uses reduce to loop/iterate through all user's messages and returns four separate categories with their corresponding messages.

_OBJECT.ENTRIES()_
We then want to use `.map` function to display them, but our types could get all mixed up with a complexity of our value (remember, `messageGroups` const has the `Record<Key, Type> ` type as `Record<MessageType, MessageData[]>`). To successfully `map` this, we use `Object.entries() `JavaScript method [[docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)] that can map objects with both keys and types.

_MAP_
`Object.entries(messageGroups).map` takes const `messageGroups` as it's parameter and then maps it using an anonymous arrow function `([type, messages]) => ( return )`. It's parameters (the message and it's type) are defined in [] array parentheses as a way to deconstruct an array of entries (so we can easily refer to it in the code). 

_RETURN_
As a return, we then display our HTML structure using Styled Components and use key and message parameters to define every message that will be displayed in a `<Message key={`${type}_${index}`} message={message} />`. The magic in the key happens because Object.entries() wanted to force our key as a string which wouldn't work so we had to be more precise with it's declaration.

Returning messages like this also allows us to say the whole `<MessageBoxBorder />` element is `hidden` when there is 0 messages (messages of lenght 0) and to display the title (to define where one MessageType starts and other begins) for the whole <MessageBoxBorder /> element, not each message.

![reduce2](https://user-images.githubusercontent.com/76131194/107968331-8584d600-6fae-11eb-985e-a6f5d5d0d2d8.png)

### COMPONENT

In the component, all that remains to do is to switch between components (each MessageType has it's own component in the Message folder due to them having different buttons/submit options).

![reduce3](https://user-images.githubusercontent.com/76131194/107979674-4317c500-6fbf-11eb-8b14-520478de3181.png)

Tadá! 

Please, feel free to ask for details! I'm barely starting to understand this myself. 

### DESKTOP / MOBILE VIEW
( I'm not solving the size of the titles yet because I presume this will be set globally when we choose the font and add appropriate rem font sizes! That's why the font is quite big on the mobile!)

![desktop](https://user-images.githubusercontent.com/76131194/107980201-24fe9480-6fc0-11eb-95c4-7d24d588032f.png)
![phone](https://user-images.githubusercontent.com/76131194/107980105-fbde0400-6fbf-11eb-8e08-0ab8c04a058c.png)

